### PR TITLE
Add cli binary

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -75,7 +75,7 @@ func (srv *Server) Start() {
 	log.Printf("Listening on %s\n", srv.Addr)
 
 	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	sig := <-quit
 	log.Println("Shutting down fupisha API server... Reason:", sig)
 

--- a/api/v1/auth/errors.go
+++ b/api/v1/auth/errors.go
@@ -7,31 +7,31 @@ import (
 	"github.com/go-chi/render"
 )
 
-//ErrInvalidEmailOrPassword a wrong email or password field.
+// ErrInvalidEmailOrPassword a wrong email or password field.
 var ErrInvalidEmailOrPassword = errors.New("invalid email or password")
 
-//ErrUnknownLogin an unregistered email field.
+// ErrUnknownLogin an unregistered email field.
 var ErrUnknownLogin = errors.New("email not registered")
 
-//ErrMissingToken a missing authorization header with the Bearer token.
+// ErrMissingToken a missing authorization header with the Bearer token.
 var ErrMissingToken = errors.New("missing authorization header")
 
-//ErrNoSuchAccount a non-existent user account.
+// ErrNoSuchAccount a non-existent user account.
 var ErrNoSuchAccount = errors.New("no such account")
 
-//ErrEmailTaken an already registered email.
+// ErrEmailTaken an already registered email.
 var ErrEmailTaken = errors.New("that email is taken")
 
-//ErrLoginToken an invalid or expired .
+// ErrLoginToken an invalid or expired .
 var ErrLoginToken = errors.New("invalid or expired login token")
 
-//ErrAPIUnsupported an unsupported api version.
+// ErrAPIUnsupported an unsupported api version.
 var ErrAPIUnsupported = errors.New("unsupported api version")
 
-//ErrMissingAPIVersion a missing api version header with the version text.
+// ErrMissingAPIVersion a missing api version header with the version text.
 var ErrMissingAPIVersion = errors.New("missing api version header")
 
-//ErrInvalidVerificationToken an expired or invalid verification token.
+// ErrInvalidVerificationToken an expired or invalid verification token.
 var ErrInvalidVerificationToken = errors.New("invalid or expired verification token")
 
 // ErrResponse renderer type for handling all sorts of errors.
@@ -45,7 +45,7 @@ type ErrResponse struct {
 }
 
 // Render sets the application-specific error code in AppCode.
-func (e *ErrResponse) Render(w http.ResponseWriter, r *http.Request) error {
+func (e *ErrResponse) Render(_ http.ResponseWriter, r *http.Request) error {
 	render.Status(r, e.HTTPStatusCode)
 	return nil
 }

--- a/api/v1/tests/auth_handlers_test.go
+++ b/api/v1/tests/auth_handlers_test.go
@@ -75,7 +75,7 @@ func TestAuth(t *testing.T) {
 			method:   "POST",
 			body:     `{"email":"parish@fupisha.io","password":"str0ngpa55w0rd"}`,
 			wantCode: http.StatusCreated,
-			wantBody: `{}`,
+			wantBody: `{"status":"OK","data":"signup successful, check your email to verify your account"}`,
 		},
 		{
 			name:     "Create a new user with an existing email",
@@ -122,7 +122,7 @@ func TestAuth(t *testing.T) {
 			url:      fmt.Sprintf("/auth/verify?v=%s", verificationToken),
 			method:   "GET",
 			wantCode: http.StatusOK,
-			wantBody: `{}`,
+			wantBody: `{"status":"OK","data":"verification successful."}`,
 		},
 	}
 

--- a/cmd/fupisha/fupisha.go
+++ b/cmd/fupisha/fupisha.go
@@ -1,4 +1,42 @@
-// Copyright  Nairobi-gophers.
-// Licensed under the AGPLv3, see LICENCE file for details.
-
 package fupisha
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/nairobi-gophers/fupisha/api"
+	"github.com/nairobi-gophers/fupisha/config"
+)
+
+func InitCmd() {
+	flag.Usage = help
+	flag.Parse()
+
+	api, err := api.NewServer()
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	cmds := map[string]func(){
+		"start": api.Start,
+		"key":   config.GenKey,
+		"help":  help,
+	}
+
+	if cmdFunc, ok := cmds[flag.Arg(0)]; ok {
+		cmdFunc()
+	} else {
+		help()
+		os.Exit(1)
+	}
+}
+
+func help() {
+	fmt.Fprintln(os.Stderr, `
+	Usage: 
+	  fupisha start		- start the server
+	  fupisha key		- generate a random 32-byte hex-encoded key         
+	 `)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,42 +1,9 @@
 package main
 
 import (
-	"flag"
-	"fmt"
-	"os"
-
-	"github.com/nairobi-gophers/fupisha/api"
-	"github.com/nairobi-gophers/fupisha/config"
+	"github.com/nairobi-gophers/fupisha/cmd/fupisha"
 )
 
 func main() {
-	flag.Usage = help
-	flag.Parse()
-
-	api, err := api.NewServer()
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
-	}
-
-	cmds := map[string]func(){
-		"start": api.Start,
-		"key":   config.GenKey,
-		"help":  help,
-	}
-
-	if cmdFunc, ok := cmds[flag.Arg(0)]; ok {
-		cmdFunc()
-	} else {
-		help()
-		os.Exit(1)
-	}
-}
-
-func help() {
-	fmt.Fprintln(os.Stderr, `
-	Usage: 
-	  fupisha start		- start the server
-	  fupisha key		- generate a random 32-byte hex-encoded key         
-	 `)
+	fupisha.InitCmd()
 }


### PR DESCRIPTION
This PR creates a separate package in the cmd directory that will ultimately be the fupisha standalone cli client. Also as a drive by we clean up some handlers and do some little formatting, linting as well as run long running tasks in their own goroutines returning responses if successful and also update tests.