### PR TITLE
Update go version in actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
       run: go vet ./...
     - name: Run staticcheck
       run: |
-         wget -O staticcheck.tgz https://github.com/dominikh/go-tools/releases/download/2021.1/staticcheck_linux_amd64.tar.gz
+         wget -O staticcheck.tgz https://github.com/dominikh/go-tools/releases/download/2022.1/staticcheck_linux_amd64.tar.gz
          sudo tar -xzf staticcheck.tgz
          ./staticcheck/staticcheck --version
          ./staticcheck/staticcheck ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.19.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:

--- a/api/v1/tests/auth_handlers_test.go
+++ b/api/v1/tests/auth_handlers_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -46,7 +46,7 @@ func TestAuth(t *testing.T) {
 	verificationToken := encoding.Encode(u.VerificationToken)
 
 	logger := logging.NewLogger(cfg)
-	logger.SetOutput(ioutil.Discard)
+	logger.SetOutput(io.Discard)
 
 	testCfg := &api.ApiConfig{
 		Logger:     logger,
@@ -127,7 +127,7 @@ func TestAuth(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		req, err := http.NewRequest(tc.method, tc.url, ioutil.NopCloser(strings.NewReader(tc.body)))
+		req, err := http.NewRequest(tc.method, tc.url, io.NopCloser(strings.NewReader(tc.body)))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/api/v1/tests/url_handlers_test.go
+++ b/api/v1/tests/url_handlers_test.go
@@ -3,7 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -79,7 +79,7 @@ func TestUrl(t *testing.T) {
 	}
 
 	logger := logging.NewLogger(cfg)
-	logger.SetOutput(ioutil.Discard)
+	logger.SetOutput(io.Discard)
 
 	testCfg := &api.ApiConfig{
 		Logger:     logger,
@@ -126,7 +126,7 @@ func TestUrl(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		req, err := http.NewRequest(tc.method, tc.url, ioutil.NopCloser(strings.NewReader(tc.body)))
+		req, err := http.NewRequest(tc.method, tc.url, io.NopCloser(strings.NewReader(tc.body)))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/fupisha/fupisha.go
+++ b/cmd/fupisha/fupisha.go
@@ -1,0 +1,4 @@
+// Copyright  Nairobi-gophers.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package fupisha


### PR DESCRIPTION
This PR bumps up the go version in the actions workflows to 1.19 and then as a drive by we also update the tests to remove the deprecated ioutil methods.